### PR TITLE
fix(deps): :arrow_up: Allow new minor projen versions

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -108,7 +108,7 @@
     },
     {
       "name": "projen",
-      "version": "^0.92.0",
+      "version": "0.* >=0.92.0",
       "type": "peer"
     }
   ],

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -16,7 +16,7 @@ const project = new JsiiProject({
   },
   majorVersion: 1,
   name: 'projen-modules',
-  peerDeps: ['constructs', 'projen@^0.92.0'],
+  peerDeps: ['constructs', 'projen@0.* >=0.92.0'],
   projenrcTs: true,
   publishToPypi: {
     distName: 'projen_modules',

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "peerDependencies": {
     "constructs": "10.4.2",
-    "projen": "^0.92.0"
+    "projen": "0.* >=0.92.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
### Background
Because projen is pre-release, `^0.92.0`, prevented projen from being upgraded to newer minor versions in projects that make use of this module.